### PR TITLE
Fix/entry point

### DIFF
--- a/.buildkite/test_build_publish.sh
+++ b/.buildkite/test_build_publish.sh
@@ -17,7 +17,7 @@ npm pack
 
 cp -v "${SCRIPT_DIR}/package.npmrc" "${PACKAGE_DIR}/.npmrc"
 sed \
-  's:"dist/cli.js":"cli.js":g'  \
+  's:dist/cli.js:cli.js:g'  \
   "${SRC_DIR}/package.json" > "${PACKAGE_DIR}/package.json"
 
 case "${BUILDKITE_BRANCH:-}" in

--- a/.buildkite/test_build_publish.sh
+++ b/.buildkite/test_build_publish.sh
@@ -16,7 +16,9 @@ npm run build
 npm pack
 
 cp -v "${SCRIPT_DIR}/package.npmrc" "${PACKAGE_DIR}/.npmrc"
-cp -v "${SRC_DIR}/package.json" "${PACKAGE_DIR}"
+sed \
+  's:"dist/cli.js":"cli.js":g'  \
+  "${SRC_DIR}/package.json" > "${PACKAGE_DIR}/package.json"
 
 case "${BUILDKITE_BRANCH:-}" in
 main) DRY_RUN=;;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "description": "A fork of Shopify's (Stephan Leroux's) command line utility for taking screenshots of a glTF 2.0 binary file using Google's <model-viewer> component.",
   "bin": {
-    "screenshot-glb": "./dist/cli.js"
+    "screenshot-glb": "dist/cli.js"
   },
   "scripts": {
     "prepare": "yarn build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geomagical/screenshot-glb",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Tickets
=======
* [CLOUD-1297](https://geomagical.atlassian.net/browse/CLOUD-1297) - Streamline Recompressor

Tech Notes
==========
* CLI entry point in dist package had wrong relative path
* This caused a warning but not an error
* In package installed from registry the entry point script was not marked as executable

build log excerpt before:
```
+ npm publish
npm warn Unknown project config "always-auth" (//us-central1-npm.pkg.dev/geomagical-prod/geomagical-js/:always-auth). This will stop working in the next major version of npm.
npm warn package-json @geomagical/screenshot-glb@1.0.0 No bin file found at dist/cli.js
```

build log excerpt after:
```
+ npm publish --dry-run
npm warn Unknown project config "always-auth" (//us-central1-npm.pkg.dev/geomagical-prod/geomagical-js/:always-auth). This will stop working in the next major version of npm.
 ```

dist/package.json excerpt before:
```
  "bin": {
    "screenshot-glb": "./dist/cli.js"
  },
```

dist/package.json excerpt after:
```
  "bin": {
    "screenshot-glb": "cli.js"
  },
```


Primary Changes
===============
* When copying package.json fix the the relative path to cli.js
* Bumpled package version so publication can succeed

Additional Changes
===================
* Ran npm pkg fix in top level repo and accepted change


Developer Testing
=================
* Functionality Checks
  * n/a
* Regression Checks
  * test suite passes
* Platforms Checked
  * [x] Linux
  * [x] macOS

Checklist
=========
* [x] Ensure PR branch is up to date with target branch
* [x] Changes covered by tests or coverage added
* [x] (npm run lint && npm run test) succeeded
