### PR TITLE
Feature/supports unpacked gltf

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,79 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="59">
+            <item index="0" class="java.lang.String" itemvalue="pluggy" />
+            <item index="1" class="java.lang.String" itemvalue="deprecated" />
+            <item index="2" class="java.lang.String" itemvalue="mypy-extensions" />
+            <item index="3" class="java.lang.String" itemvalue="pre-commit" />
+            <item index="4" class="java.lang.String" itemvalue="marshmallow" />
+            <item index="5" class="java.lang.String" itemvalue="setuptools" />
+            <item index="6" class="java.lang.String" itemvalue="numpy" />
+            <item index="7" class="java.lang.String" itemvalue="requests" />
+            <item index="8" class="java.lang.String" itemvalue="filelock" />
+            <item index="9" class="java.lang.String" itemvalue="pytest-cov" />
+            <item index="10" class="java.lang.String" itemvalue="certifi" />
+            <item index="11" class="java.lang.String" itemvalue="numpy-quaternion" />
+            <item index="12" class="java.lang.String" itemvalue="urllib3" />
+            <item index="13" class="java.lang.String" itemvalue="coverage" />
+            <item index="14" class="java.lang.String" itemvalue="pydantic" />
+            <item index="15" class="java.lang.String" itemvalue="nodeenv" />
+            <item index="16" class="java.lang.String" itemvalue="identify" />
+            <item index="17" class="java.lang.String" itemvalue="pytest" />
+            <item index="18" class="java.lang.String" itemvalue="iniconfig" />
+            <item index="19" class="java.lang.String" itemvalue="wrapt" />
+            <item index="20" class="java.lang.String" itemvalue="packaging" />
+            <item index="21" class="java.lang.String" itemvalue="typing-extensions" />
+            <item index="22" class="java.lang.String" itemvalue="pyyaml" />
+            <item index="23" class="java.lang.String" itemvalue="dataclasses-json" />
+            <item index="24" class="java.lang.String" itemvalue="platformdirs" />
+            <item index="25" class="java.lang.String" itemvalue="typing-inspect" />
+            <item index="26" class="java.lang.String" itemvalue="virtualenv" />
+            <item index="27" class="java.lang.String" itemvalue="charset-normalizer" />
+            <item index="28" class="java.lang.String" itemvalue="distlib" />
+            <item index="29" class="java.lang.String" itemvalue="pygltflib" />
+            <item index="30" class="java.lang.String" itemvalue="cfgv" />
+            <item index="31" class="java.lang.String" itemvalue="idna" />
+            <item index="32" class="java.lang.String" itemvalue="httpx" />
+            <item index="33" class="java.lang.String" itemvalue="six" />
+            <item index="34" class="java.lang.String" itemvalue="python-dateutil" />
+            <item index="35" class="java.lang.String" itemvalue="kiwisolver" />
+            <item index="36" class="java.lang.String" itemvalue="google-cloud-storage" />
+            <item index="37" class="java.lang.String" itemvalue="cycler" />
+            <item index="38" class="java.lang.String" itemvalue="imgcat" />
+            <item index="39" class="java.lang.String" itemvalue="trimesh" />
+            <item index="40" class="java.lang.String" itemvalue="redis" />
+            <item index="41" class="java.lang.String" itemvalue="dagster-geomagical" />
+            <item index="42" class="java.lang.String" itemvalue="Celery" />
+            <item index="43" class="java.lang.String" itemvalue="matplotlib" />
+            <item index="44" class="java.lang.String" itemvalue="pyparsing" />
+            <item index="45" class="java.lang.String" itemvalue="Pillow" />
+            <item index="46" class="java.lang.String" itemvalue="google-crc32c" />
+            <item index="47" class="java.lang.String" itemvalue="kombu" />
+            <item index="48" class="java.lang.String" itemvalue="fonttools" />
+            <item index="49" class="java.lang.String" itemvalue="rsa" />
+            <item index="50" class="java.lang.String" itemvalue="cyclopts" />
+            <item index="51" class="java.lang.String" itemvalue="prompt_toolkit" />
+            <item index="52" class="java.lang.String" itemvalue="pyasn1_modules" />
+            <item index="53" class="java.lang.String" itemvalue="googleapis-common-protos" />
+            <item index="54" class="java.lang.String" itemvalue="typing_extensions" />
+            <item index="55" class="java.lang.String" itemvalue="tzdata" />
+            <item index="56" class="java.lang.String" itemvalue="contourpy" />
+            <item index="57" class="java.lang.String" itemvalue="google-auth" />
+            <item index="58" class="java.lang.String" itemvalue="httpcore" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="src.tool_scripts.tests.test_gen_api_sources.gen_api_sources" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/screenshot-glb.iml" filepath="$PROJECT_DIR$/.idea/screenshot-glb.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PrettierConfiguration">
+    <option name="myConfigurationMode" value="AUTOMATIC" />
+  </component>
+</project>

--- a/.idea/runConfigurations/multiple_ss_for_glb.xml
+++ b/.idea/runConfigurations/multiple_ss_for_glb.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="multiple ss for glb" type="NodeJSConfigurationType" application-parameters="-i $PROJECT_DIR$/test/fixtures/microphone.glb -o $PROJECT_DIR$/test/microphone.png -m camera-orbit=0deg%2075deg%20105%25 -m camera-orbit=30deg%2075deg%20105%25 -m camera-orbit=30deg%2060deg%20105%25" path-to-js-file="src/cli.ts" typescript-loader="bundled" working-dir="$PROJECT_DIR$">
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/multiple_ss_for_gltf.xml
+++ b/.idea/runConfigurations/multiple_ss_for_gltf.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="multiple ss for gltf" type="NodeJSConfigurationType" application-parameters="-i ./test/fixtures/WaterBottle/WaterBottle.gltf -o ./test/waterbottle.png -m camera-orbit=0deg%2075deg%20105%25 -m camera-orbit=30deg%2075deg%20105%25 -m camera-orbit=30deg%2060deg%20105%25" path-to-js-file="src/cli.ts" typescript-loader="bundled" working-dir="$PROJECT_DIR$">
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/screenshot-glb.iml
+++ b/.idea/screenshot-glb.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geomagical/screenshot-glb",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "publishConfig": {
     "access": "public"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,10 +113,10 @@ const argv = yargs(process.argv.slice(2)).options({
   // NOTE: this is less suitable for general public use.
   // it is an optimization for geomagical's use case.
   const localServer = new FileServer(path.dirname(argv.input));
-  await localServer.start();
-
   let options: CaptureScreenShotOptions;
   let processStatus = 0;
+
+  await localServer.start();
 
   try {
     options = await prepareAppOptions({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,23 +107,23 @@ const argv = yargs(process.argv.slice(2)).options({
     process.exit(processStatus);
   }
 
-  let localServer : FileServer;
+  // serve entire directory instead of using file handler
+  // to server out of temp directory and copy one glb file.
+  // allows for exploded GLTFs to be handled and saves file copying.
+  // NOTE: this is less suitable for general public use.
+  // it is an optimization for geomagical's use case.
+  const localServer = new FileServer(path.dirname(argv.input));
+  await localServer.start();
+
   let options: CaptureScreenShotOptions;
   let processStatus = 0;
 
   try {
     options = await prepareAppOptions({
-      localServerPort: FileServer.PORT,
+      localServerPort: localServer.port,
       fileHandler: undefined,
       argv,
     });
-    // serve entire directory instead of using file handler
-    // to server out of temp directory and copy one glb file.
-    // allows for exploded GLTFs to be handled and saves file copying.
-    // NOTE: this is less suitable for general public use.
-    // it is an optimization for geomagical's use case.
-    localServer = new FileServer(path.dirname(argv.input));
-    await localServer.start();
   } catch (error) {
     logError(error);
     processStatus = 1;

--- a/src/file-server.ts
+++ b/src/file-server.ts
@@ -44,7 +44,6 @@ const createFileServer = (mountDirectory) => {
 };
 
 export class FileServer {
-  static PORT: number = 8384
   port: number;
   mountDirectory: string;
   private server: http.Server;
@@ -58,7 +57,7 @@ export class FileServer {
     const server = createFileServer(this.mountDirectory);
 
     return new Promise<number>((resolve) => {
-      server.listen(FileServer.PORT, () => {
+      server.listen(0, () => {
         resolve((server.address() as AddressInfo).port);
       });
     }).then((port) => {

--- a/src/file-server.ts
+++ b/src/file-server.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import {AddressInfo} from 'net';
 
 const createFileServer = (mountDirectory) => {
-  return http.createServer( (request, response) => {
+  return http.createServer((request, response) => {
     const filePath = path.join(mountDirectory, request.url);
     const extname = String(path.extname(filePath)).toLowerCase();
     const mimeTypes = {

--- a/src/file-server.ts
+++ b/src/file-server.ts
@@ -4,12 +4,16 @@ import path from 'path';
 import {AddressInfo} from 'net';
 
 const createFileServer = (mountDirectory) => {
-  return http.createServer((request, response) => {
+  return http.createServer( (request, response) => {
     const filePath = path.join(mountDirectory, request.url);
     const extname = String(path.extname(filePath)).toLowerCase();
     const mimeTypes = {
       '.glb': 'application/gltf-binary',
       '.js': 'application/javascript',
+      '.gltf': 'application/gltf',
+      '.png': 'image/png',
+      '.jpg': 'image/jpeg',
+      '.webp': 'image/webp',
     };
 
     const contentType = mimeTypes[extname] || 'application/octet-stream';
@@ -40,6 +44,7 @@ const createFileServer = (mountDirectory) => {
 };
 
 export class FileServer {
+  static PORT: number = 8384
   port: number;
   mountDirectory: string;
   private server: http.Server;
@@ -53,7 +58,7 @@ export class FileServer {
     const server = createFileServer(this.mountDirectory);
 
     return new Promise<number>((resolve) => {
-      server.listen(0, () => {
+      server.listen(FileServer.PORT, () => {
         resolve((server.address() as AddressInfo).port);
       });
     }).then((port) => {

--- a/src/file-server.ts
+++ b/src/file-server.ts
@@ -8,11 +8,13 @@ const createFileServer = (mountDirectory) => {
     const filePath = path.join(mountDirectory, request.url);
     const extname = String(path.extname(filePath)).toLowerCase();
     const mimeTypes = {
-      '.glb': 'application/gltf-binary',
-      '.js': 'application/javascript',
-      '.gltf': 'application/gltf',
-      '.png': 'image/png',
+      '.glb': 'model/gltf-binary',
+      '.gltf': 'model/gltf+json',
+      '.jpeg': 'image/jpeg',
       '.jpg': 'image/jpeg',
+      '.js': 'application/javascript',
+      '.json': 'application/json',
+      '.png': 'image/png',
       '.webp': 'image/webp',
     };
 

--- a/src/prepare-app-options.test.ts
+++ b/src/prepare-app-options.test.ts
@@ -1,7 +1,7 @@
 import {prepareAppOptions, PrepareAppOptionsArgs} from './prepare-app-options';
 import {CaptureScreenShotOptions} from './types/CaptureScreenshotOptions';
 import {checkFileExistsAtUrl} from './check-file-exists-at-url';
-import {copyFile} from 'fs';
+// import {copyFile} from 'fs';
 import {FileHandler} from './file-handler';
 
 jest.mock('./check-file-exists-at-url');
@@ -105,6 +105,10 @@ test('handles jpg with color override', async () => {
   });
 });
 
+// eliminate test - file serving is done out of the
+// input file's directory directly, not from a temp
+// directory with a single copied file
+/*
 test('copies glb to server folder', async () => {
   const argv = getArgv();
   await expect(prepareAppOptions({...defaultArgs, argv}));
@@ -112,6 +116,7 @@ test('copies glb to server folder', async () => {
   expect(fileHandler.addFile).toBeCalledTimes(1);
   expect(fileHandler.addFile).toHaveBeenCalledWith(argv.input);
 });
+*/
 
 test('handles model viewer attributes', async () => {
   const argv = getArgv({
@@ -169,6 +174,10 @@ test('errors if local model viewer path + version are passed', async () => {
   );
 });
 
+// eliminate test - file serving is done out of the
+// input file's directory directly, not from a temp
+// directory with a single copied file
+/*
 test('handles local model viewer path for model viewer', async () => {
   const modelViewerPath = './model-viewer.js';
   const argv = getArgv({
@@ -185,3 +194,4 @@ test('handles local model viewer path for model viewer', async () => {
   expect(fileHandler.addFile).toHaveBeenCalledWith(argv.input);
   expect(fileHandler.addFile).toHaveBeenCalledWith(modelViewerPath);
 });
+ */

--- a/src/prepare-app-options.ts
+++ b/src/prepare-app-options.ts
@@ -49,7 +49,8 @@ export async function prepareAppOptions({
     model_viewer_version: modelViewerVersion,
     model_viewer_path: modelViewerPath,
   } = argv;
-  const model3dFileName = await fileHandler.addFile(input);
+  // const model3dFileName = await fileHandler.addFile(input);
+  const model3dFileName = path.basename(input)
   const inputPath = getLocalUrl({
     port: localServerPort,
     fileName: model3dFileName,

--- a/src/prepare-app-options.ts
+++ b/src/prepare-app-options.ts
@@ -49,7 +49,6 @@ export async function prepareAppOptions({
     model_viewer_version: modelViewerVersion,
     model_viewer_path: modelViewerPath,
   } = argv;
-  // const model3dFileName = await fileHandler.addFile(input);
   const model3dFileName = path.basename(input)
   const inputPath = getLocalUrl({
     port: localServerPort,

--- a/src/prepare-app-options.ts
+++ b/src/prepare-app-options.ts
@@ -49,7 +49,7 @@ export async function prepareAppOptions({
     model_viewer_version: modelViewerVersion,
     model_viewer_path: modelViewerPath,
   } = argv;
-  const model3dFileName = path.basename(input)
+  const model3dFileName = path.basename(input);
   const inputPath = getLocalUrl({
     port: localServerPort,
     fileName: model3dFileName,

--- a/test/scripts/explode_glb.sh
+++ b/test/scripts/explode_glb.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+THIS_SCRIPT=$(basename "${0}")
+#SCRIPT_DIR=$(DIR=$(dirname "${0}") && cd "${DIR}" && pwd)
+#PATH=${PATH}:${SCRIPT_DIR}
+
+function error() {
+    echo "$*" 1>&2
+    exit 1
+}
+
+if ! (which gltf-pipeline 2>&1) > /dev/null; then
+  error "npm install -g gltf-pipeline first." 1>&2
+fi
+
+if [[ ! -f "${1}" || "${1}" != *.glb ]]; then
+  error "usage: ${THIS_SCRIPT} <input.glb>" 1>&2
+fi
+
+GLB=${1}
+GLTF_DIR=${GLB%.glb}
+GLTF_NAME=$(basename "${GLTF_DIR}").gltf
+GLTF=${GLTF_DIR}/${GLTF_NAME}
+
+[[ ! -d "${GLTF_DIR}" ]] || error "${GLTF_DIR} already exists."
+
+echo "exploding ${GLB} into ${GLTF}"
+mkdir "${GLTF_DIR}"
+exec gltf-pipeline --input="${GLB}" --output="${GLTF}" --separate


### PR DESCRIPTION
Tickets
=======
* [CLOUD-1297](https://geomagical.atlassian.net/browse/CLOUD-1297) - Recompressor Streamlining


Tech Notes
==========
* Support for screenshotting unpacked GLTFs will save some complexity and overhead for recompressor.
* Eliminates yet another file copy

Primary Changes
===============
* FileHandler no longer used
  * It used to make a temp dir and copy input file to it
  * FileServer would then serve only the temp dir
* FileServer usage changed to serve entire parent directory of input file
* tests checking for FileHandler usage commented out
* Bumped package version to 1.1.0

Additional Changes
===================
* Added utility script for exploding a glb to a gltf for testing new behavior
* Added .idea/ common IDE settings

Developer Testing
=================
* Functionality Checks
  * Verified new behavior works
  * Verified works when --input=file.name (no relative or absolute path)
* Regression Checks
  * Verified still works with single GLB file
  * Other tests pass
* Platforms Checked
  * [ ] Linux
  * [x] macOS

Checklist
=========
* [x] Ensure PR branch is up to date with target branch
* [ ] Changes covered by tests or coverage added
* [x] (npm run lint && npm run test) succeeded
