### PR TITLE
Fix/environment neutral

### DIFF
--- a/.idea/runConfigurations/specify_env_map.xml
+++ b/.idea/runConfigurations/specify_env_map.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="specify env map" type="NodeJSConfigurationType" application-parameters="-i $PROJECT_DIR$/test/fixtures/Astronaut.glb -o $PROJECT_DIR$/test/Astronaut.png -c #ffffff -m environment-image=environment.hdr" path-to-js-file="src/cli.ts" typescript-loader="bundled" working-dir="$PROJECT_DIR$">
+    <method v="2" />
+  </configuration>
+</component>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geomagical/screenshot-glb",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/src/prepare-app-options.ts
+++ b/src/prepare-app-options.ts
@@ -69,7 +69,9 @@ export async function prepareAppOptions({
       let args: {[key: string]: string} = {};
       const params = new URLSearchParams(attrs);
       params.forEach((value, key) => {
-        if (key == 'environment-image' || key == 'skybox-image') {
+        // if value has an extension convert to url.
+        // otherwise do not.
+        if (key == 'environment-image' || key == 'skybox-image' && value.includes(".")) {
           args[key] = getLocalUrl({
             port: localServerPort,
             fileName: value,

--- a/src/prepare-app-options.ts
+++ b/src/prepare-app-options.ts
@@ -71,7 +71,7 @@ export async function prepareAppOptions({
       params.forEach((value, key) => {
         // if value has an extension convert to url.
         // otherwise do not.
-        if (key == 'environment-image' || key == 'skybox-image' && value.includes(".")) {
+        if ((key == 'environment-image' || key == 'skybox-image') && value.includes(".")) {
           args[key] = getLocalUrl({
             port: localServerPort,
             fileName: value,

--- a/src/prepare-app-options.ts
+++ b/src/prepare-app-options.ts
@@ -71,7 +71,10 @@ export async function prepareAppOptions({
       params.forEach((value, key) => {
         // if value has an extension convert to url.
         // otherwise do not.
-        if ((key == 'environment-image' || key == 'skybox-image') && value.includes(".")) {
+        if (
+          (key == 'environment-image' || key == 'skybox-image') &&
+          value.includes('.')
+        ) {
           args[key] = getLocalUrl({
             port: localServerPort,
             fileName: value,


### PR DESCRIPTION
Tech Notes
==========
* When specifying non-file environment-image or skybox parameters (keywords like neutral or legacy) the parameter value should not be converted to a url

Primary Changes
===============
* check for '.' in value specified for environment-image or skybox-image attributes passed to model_viewer through -m
* bumped package patch version
 
Additional Changes
===================
* Fixed file serving for --model_viewer local_model_viewer.js


Developer Testing
=================
* Functionality Checks
  * Verified specifying legacy or neutral environment-image does not covert value to url in debugger
* Regression Checks
  * Test suite still passes
* Platforms Checked
  * [ ] Linux
  * [x] macOS

Checklist
=========
* [x] Ensure PR branch is up to date with target branch
* [ ] Changes covered by tests or coverage added
* [x] (npm run lint && npm run test) succeeded
