### PR TITLE
Fix/interpolation decay 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geomagical/screenshot-glb",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "publishConfig": {
     "access": "public"
   },

--- a/src/html-template.ts
+++ b/src/html-template.ts
@@ -64,6 +64,7 @@ export function htmlTemplate({
     id: 'snapshot-viewer',
     style: `background-color: ${backgroundColor};`,
     'interaction-prompt': 'none',
+    'interpolation-decay': 0,
     src: inputPath,
   };
 


### PR DESCRIPTION
Set interpolation-decay to 0 to ensure each camera-orbit config is exact when the screen capture is taken instead of possibly being mid-interpolation.